### PR TITLE
1.21.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.8-SNAPSHOT'
+	id 'fabric-loom' version '1.9-SNAPSHOT'
 	id 'maven-publish'
 	id "com.modrinth.minotaur" version "2.8.7"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
+minecraft_version=1.21.3
+yarn_mappings=1.21.3+build.2
 loader_version=0.16.10
 # Mod Properties
 mod_name=resolutioncontrol
@@ -13,9 +13,9 @@ maven_group=cc.modlabs
 archives_base_name=resolution-control-plus-plus
 
 # Dependencies
-fabric_version=0.114.2+1.21.4
+fabric_version=0.114.0+1.21.3
 
-mod_menu_version=13.0.0
+mod_menu_version=12.0.0
 
 #Modrinth
 modrinth_id = SBESx1ZS

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.21.3
-yarn_mappings=1.21.3+build.2
-loader_version=0.16.9
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.8
+loader_version=0.16.10
 # Mod Properties
 mod_name=resolutioncontrol
 mod_version=3.0.3
@@ -13,9 +13,9 @@ maven_group=cc.modlabs
 archives_base_name=resolution-control-plus-plus
 
 # Dependencies
-fabric_version=0.112.1+1.21.3
+fabric_version=0.114.2+1.21.4
 
-mod_menu_version=12.0.0
+mod_menu_version=13.0.0
 
 #Modrinth
 modrinth_id = SBESx1ZS

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/cc/modlabs/resolutioncontrol/ResolutionControlMod.java
+++ b/src/main/java/cc/modlabs/resolutioncontrol/ResolutionControlMod.java
@@ -32,32 +32,32 @@ public class ResolutionControlMod implements ModInitializer {
 	public static final String MOD_NAME = "ResolutionControl++";
 
 	public static final Logger LOGGER = LogManager.getLogger(MOD_NAME);
-	
+
 	public static Identifier identifier(String path) {
 		return Identifier.of(MOD_ID, path);
 	}
-	
+
 	private static final MinecraftClient client = MinecraftClient.getInstance();
-	
+
 	private static ResolutionControlMod instance;
-	
+
 	public static ResolutionControlMod getInstance() {
 		return instance;
 	}
 
 	private static final String SCREENSHOT_PREFIX = "fb";
-	
+
 	private KeyBinding settingsKey;
 	private KeyBinding screenshotKey;
-	
+
 	private boolean shouldScale = false;
-	
+
 	@Nullable
 	private Framebuffer framebuffer;
 
 	@Nullable
 	private Framebuffer screenshotFrameBuffer;
-	
+
 	@Nullable
 	private Framebuffer clientFramebuffer;
 
@@ -75,11 +75,11 @@ public class ResolutionControlMod implements ModInitializer {
 	private int lastWidth;
 	private int lastHeight;
 	public boolean hasRun = false;
-	
+
 	@Override
 	public void onInitialize() {
 		instance = this;
-		
+
 		settingsKey = KeyBindingHelper.registerKeyBinding(new KeyBinding(
 				"key.resolutioncontrol.settings",
 				InputUtil.Type.KEYSYM,
@@ -148,12 +148,12 @@ public class ResolutionControlMod implements ModInitializer {
 				fb,
 				text -> client.player.sendMessage(text, false));
 	}
-	
+
 	public void setShouldScale(boolean shouldScale) {
 		if (shouldScale == this.shouldScale) return;
 
 //		if (getScaleFactor() == 1) return;
-		
+
 		Window window = getWindow();
 		if (framebuffer == null) {
 			this.shouldScale = true; // so we get the right dimensions
@@ -241,16 +241,16 @@ public class ResolutionControlMod implements ModInitializer {
 				getScreenshotWidth(), getScreenshotHeight()
 		);
 	}
-	
+
 	public float getScaleFactor() {
 		return Config.getInstance().scaleFactor;
 	}
-	
+
 	public void setScaleFactor(float scaleFactor) {
 		Config.getInstance().scaleFactor = scaleFactor;
-		
+
 		updateFramebufferSize();
-		
+
 		ConfigHandler.instance.saveConfig();
 	}
 
@@ -299,7 +299,7 @@ public class ResolutionControlMod implements ModInitializer {
 			setDownscaleAlgorithm(ScalingAlgorithm.NEAREST);
 		}
 	}
-	
+
 	public double getCurrentScaleFactor() {
 		return shouldScale ?
 				Config.getInstance().enableDynamicResolution ?
@@ -373,21 +373,21 @@ public class ResolutionControlMod implements ModInitializer {
 //		if (getWindow().getScaledHeight() == lastWidth
 //				|| getWindow().getScaledHeight() == lastHeight)
 //		{
-			updateFramebufferSize();
+		updateFramebufferSize();
 
-			lastWidth = getWindow().getScaledHeight();
-			lastHeight = getWindow().getScaledHeight();
+		lastWidth = getWindow().getScaledHeight();
+		lastHeight = getWindow().getScaledHeight();
 //		}
 
 
 	}
-	
+
 	public void updateFramebufferSize() {
 		if (framebuffer == null)
 			return;
 
 		resize(framebuffer);
-		resize(client.worldRenderer.getEntityOutlinesFramebuffer());
+		resize(client.worldRenderer.entityOutlineFramebuffer);
 		resizeMinecraftFramebuffers();
 
 		calculateSize();
@@ -405,7 +405,7 @@ public class ResolutionControlMod implements ModInitializer {
 		// Framebuffer uses color (4 x 8 = 32 bit int) and depth (32 bit float)
 		estimatedMemory = (long) currentWidth * currentHeight * 8;
 	}
-	
+
 	public void resize(@Nullable Framebuffer framebuffer) {
 		if (framebuffer == null) return;
 
@@ -425,11 +425,11 @@ public class ResolutionControlMod implements ModInitializer {
 		}
 		shouldScale = prev;
 	}
-	
+
 	private Window getWindow() {
 		return client.getWindow();
 	}
-	
+
 	private void setClientFramebuffer(Framebuffer framebuffer) {
 		client.framebuffer = framebuffer;
 	}


### PR DESCRIPTION
- version bumped dependencies
- gradle wrapper 8.10 -> 8.11 as required by net.fabricmc:fabric-loom:1.9-SNAPSHOT
- changed getEntityOutlinesFramebuffer() call to .entityOutlineFramebuffer, as the call returns null-- causing entities to not be resized at all (see last screenshot of #9)
- removed errant tabs on empty lines that I can't make my IDE stop removing, sorry